### PR TITLE
Don't create unnecessary S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@
 ## How to clean up
 
 1. Stop the "PanoramaWorkshop" instance from [SageMaker Notebooks instances page](https://console.aws.amazon.com/sagemaker/home#/notebook-instances).
-1. Empty the contents of S3 bucket panorama-workshop-{account-id}.
+
+1. Empty the contents of following S3 path.
     ```
-    $ aws s3 rm s3://panorama-workshop-{account-id} --recursive
+    $ aws s3 rm s3://sagemaker-{region}-{account-id}/panorama-workshop --recursive
     ```
+
 1. Delete the CloudFormation stack.
     ```
     $ aws cloudformation delete-stack --stack-name panorama-workshop-1

--- a/cloudformation/cf-panorama-workshop.yaml
+++ b/cloudformation/cf-panorama-workshop.yaml
@@ -109,15 +109,3 @@ Resources:
       LifecycleConfigName: PanoramaWorkshopNotebookLifecycle
       RoleArn: !GetAtt PanoramaWorkshopNotebookIamRole.Arn
       VolumeSizeInGB: !Ref VolumeSize
-
-  # S3 bucket for Test Utility's model compilation
-  PanoramaWorkshopBucket:
-    Type: "AWS::S3::Bucket"
-    Properties:
-      BucketName: # panorama-workshop-{aws account id}
-        !Join
-        - ''
-        - - 'panorama-workshop-'
-          - !Ref AWS::AccountId
-      PublicAccessBlockConfiguration:
-        RestrictPublicBuckets : TRUE


### PR DESCRIPTION
*Description of changes:*

Don't create S3 bucket unnecessarily.
In the Labs, we use sagemaker.default_bucket(), and we don't have to create bucket additionally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
